### PR TITLE
Allow using a custom namespace for the kubeless controller

### DIFF
--- a/cmd/kubeless/install.go
+++ b/cmd/kubeless/install.go
@@ -33,8 +33,14 @@ By default we will install the latest release of bitnami/kubeless-controller ima
 Use your own controller by specifying --controller-image flag.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Default namespace
+		ctlNamespace, err := cmd.Flags().GetString("controller-namespace")
+		if err != nil {
+			logrus.Fatal(err)
+		}
 		okayResponses := []string{"y", "Y", "yes", "Yes", "YES"}
-		fmt.Println("We are going to install the controller into the kubeless namespace. [Y/n]?")
+		// ToDo martin: this fmt doesn't work
+		fmt.Println("We are going to install the controller into the '" + ctlNamespace + "' namespace. [Y/n]?")
 		var text string
 		n, _ := fmt.Scanln(&text)
 		if n < 1 {
@@ -42,7 +48,9 @@ Use your own controller by specifying --controller-image flag.
 			text = "Y"
 		}
 
-		//getting versions
+		// Additional user flags
+
+
 		ctlImage, err := cmd.Flags().GetString("controller-image")
 		if err != nil {
 			logrus.Fatal(err)
@@ -56,8 +64,8 @@ Use your own controller by specifying --controller-image flag.
 			cfg := controller.NewControllerConfig("", "")
 			c := controller.New(cfg)
 			c.Init()
-			c.InstallKubeless(ctlImage)
-			c.InstallMsgBroker(kafkaVer)
+			c.InstallKubeless(ctlImage, ctlNamespace)
+			c.InstallMsgBroker(kafkaVer, ctlNamespace)
 		} else {
 			fmt.Println("Kubeless wasn't installed, exiting.")
 			return
@@ -79,6 +87,7 @@ func posString(slice []string, element string) int {
 }
 
 func init() {
+	installCmd.Flags().StringP("controller-namespace", "", "kubeless", "Install Kubeless to a specific namespace. It will default to 'kubeless'")
 	installCmd.Flags().StringP("controller-image", "", "", "Install a specific image of Kubeless controller")
 	installCmd.Flags().StringP("kafka-version", "", "", "Install a specific version of Kafka")
 }

--- a/cmd/kubeless/topicDelete.go
+++ b/cmd/kubeless/topicDelete.go
@@ -29,9 +29,13 @@ var topicDeleteCmd = &cobra.Command{
 		if len(args) != 1 {
 			logrus.Fatal("Need exactly one argument - topic name")
 		}
+                ctlNamespace, err := cmd.Flags().GetString("controller-namespace")
+                if err != nil {
+                        logrus.Fatal(err)
+                }
 		topicName := args[0]
 		command := []string{"bash", "/opt/kafka/bin/kafka-topics.sh", "--zookeeper", "zookeeper:2181", "--delete", "--topic", topicName}
 
-		execCommand(command)
+		execCommand(command, ctlNamespace)
 	},
 }

--- a/cmd/kubeless/topicList.go
+++ b/cmd/kubeless/topicList.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+        "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +27,11 @@ var topicListCmd = &cobra.Command{
 	Short:   "list all topics created in Kubeless",
 	Long:    `list all topics created in Kubeless`,
 	Run: func(cmd *cobra.Command, args []string) {
+                ctlNamespace, err := cmd.Flags().GetString("controller-namespace")
+                if err != nil {
+                        logrus.Fatal(err)
+                }
 		command := []string{"bash", "/opt/kafka/bin/kafka-topics.sh", "--zookeeper", "zookeeper:2181", "--list"}
-		execCommand(command)
+		execCommand(command, ctlNamespace)
 	},
 }

--- a/cmd/kubeless/topicPublish.go
+++ b/cmd/kubeless/topicPublish.go
@@ -38,17 +38,23 @@ var topicPublishCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+                ctlNamespace, err := cmd.Flags().GetString("controller-namespace")
+                if err != nil {
+                        logrus.Fatal(err)
+                }
+
 		body := fmt.Sprintf(`echo %s > msg.txt`, data)
 		command := []string{"bash", "-c", body}
-		execCommand(command)
+		execCommand(command, ctlNamespace)
 
 		body = fmt.Sprintf(`/opt/kafka/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic %s < msg.txt`, topic)
 		command = []string{"bash", "-c", body}
-		execCommand(command)
+		execCommand(command, ctlNamespace)
 	},
 }
 
 func init() {
+	topicPublishCmd.Flags().StringP("controller-namespace", "", "kubeless", "Install Kubeless Topic to a specific namespace. It will default to 'kubeless'")
 	topicPublishCmd.Flags().StringP("data", "", "", "Specify data for function")
 	topicPublishCmd.Flags().StringP("topic", "", "kubeless", "Specify topic name")
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -90,23 +90,23 @@ func (c *Controller) Init() {
 	}
 }
 
-func (c *Controller) InstallKubeless(ctlImage string) {
+func (c *Controller) InstallKubeless(ctlImage string, ctlNamespace string) {
 	c.logger.Infof("Installing Kubeless controller into Kubernetes deployment...")
-	err := utils.DeployKubeless(c.Config.KubeCli, ctlImage)
+	err := utils.DeployKubeless(c.Config.KubeCli, ctlImage, ctlNamespace)
 	if err != nil {
 		c.logger.Errorf("Kubeless controller installation failed: %v", err)
 	} else {
-		c.logger.Infof("Kubeless controller installation finished!")
+		c.logger.Infof("Kubeless controller installation successful!")
 	}
 }
 
-func (c *Controller) InstallMsgBroker(kafkaVer string) {
+func (c *Controller) InstallMsgBroker(kafkaVer string, ctlNamespace string) {
 	c.logger.Infof("Installing Message Broker into Kubernetes deployment...")
-	err := utils.DeployMsgBroker(c.Config.KubeCli, kafkaVer)
+	err := utils.DeployMsgBroker(c.Config.KubeCli, kafkaVer, ctlNamespace)
 	if err != nil {
 		c.logger.Errorf("Message Broker installation failed: %v", err)
 	} else {
-		c.logger.Infof("Message Broker installation finished!")
+		c.logger.Infof("Message Broker installation successful!")
 	}
 }
 


### PR DESCRIPTION
I have made the K8s namespace that Kubeless installs on configurable for multi-user clusters.
There's some clear refactorings in the future:
 - The namespace switch needs to be passed to each command, which isn't ideal
 - There's a lot of passing around of ctlNamespace which could probably be obtained from somewhere central (maybe by setting DefaultNamespace in pkg/utils/k8sutil.go?
 - pkg/utils/k8sutil.go hardcodes the internal hosts and ports, they might also ideally be pulled from context and configurable as well