### PR TITLE
fix for kafka namespace flag

### DIFF
--- a/cmd/kubeless/topic.go
+++ b/cmd/kubeless/topic.go
@@ -30,8 +30,10 @@ var topicCmd = &cobra.Command{
 }
 
 func init() {
-	topicCmd.AddCommand(topicCreateCmd)
-	topicCmd.AddCommand(topicDeleteCmd)
-	topicCmd.AddCommand(topicListCmd)
-	topicCmd.AddCommand(topicPublishCmd)
+	cmds := []*cobra.Command{topicCreateCmd, topicDeleteCmd, topicListCmd, topicPublishCmd}
+
+	for _, cmd := range cmds {
+		topicCmd.AddCommand(cmd)
+		cmd.Flags().StringP("kafka-namespace", "", "kubeless", "---Namespace where kafka-controller is deployed. It will default to 'kubeless'")
+	}
 }

--- a/cmd/kubeless/topic.go
+++ b/cmd/kubeless/topic.go
@@ -34,6 +34,6 @@ func init() {
 
 	for _, cmd := range cmds {
 		topicCmd.AddCommand(cmd)
-		cmd.Flags().StringP("kafka-namespace", "", "kubeless", "---Namespace where kafka-controller is deployed. It will default to 'kubeless'")
+		cmd.Flags().StringP("kafka-namespace", "", "kubeless", "Namespace where kafka-controller is deployed. It will default to 'kubeless'")
 	}
 }

--- a/cmd/kubeless/topicCreate.go
+++ b/cmd/kubeless/topicCreate.go
@@ -35,7 +35,7 @@ var topicCreateCmd = &cobra.Command{
 		if len(args) != 1 {
 			logrus.Fatal("Need exactly one argument - topic name")
 		}
-                ctlNamespace, err := cmd.Flags().GetString("controller-namespace")
+                ctlNamespace, err := cmd.Flags().GetString("kafka-namespace")
                 if err != nil {
                         logrus.Fatal(err)
                 }

--- a/cmd/kubeless/topicDelete.go
+++ b/cmd/kubeless/topicDelete.go
@@ -29,7 +29,7 @@ var topicDeleteCmd = &cobra.Command{
 		if len(args) != 1 {
 			logrus.Fatal("Need exactly one argument - topic name")
 		}
-                ctlNamespace, err := cmd.Flags().GetString("controller-namespace")
+                ctlNamespace, err := cmd.Flags().GetString("kafka-namespace")
                 if err != nil {
                         logrus.Fatal(err)
                 }

--- a/cmd/kubeless/topicList.go
+++ b/cmd/kubeless/topicList.go
@@ -27,7 +27,7 @@ var topicListCmd = &cobra.Command{
 	Short:   "list all topics created in Kubeless",
 	Long:    `list all topics created in Kubeless`,
 	Run: func(cmd *cobra.Command, args []string) {
-                ctlNamespace, err := cmd.Flags().GetString("controller-namespace")
+                ctlNamespace, err := cmd.Flags().GetString("kafka-namespace")
                 if err != nil {
                         logrus.Fatal(err)
                 }

--- a/cmd/kubeless/topicPublish.go
+++ b/cmd/kubeless/topicPublish.go
@@ -38,7 +38,7 @@ var topicPublishCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-                ctlNamespace, err := cmd.Flags().GetString("controller-namespace")
+                ctlNamespace, err := cmd.Flags().GetString("kafka-namespace")
                 if err != nil {
                         logrus.Fatal(err)
                 }
@@ -54,7 +54,6 @@ var topicPublishCmd = &cobra.Command{
 }
 
 func init() {
-	topicPublishCmd.Flags().StringP("controller-namespace", "", "kubeless", "Install Kubeless Topic to a specific namespace. It will default to 'kubeless'")
 	topicPublishCmd.Flags().StringP("data", "", "", "Specify data for function")
 	topicPublishCmd.Flags().StringP("topic", "", "kubeless", "Specify topic name")
 }


### PR DESCRIPTION
The `topic` command was broken (only the `publish` verb was working).

This fixes that.

Also, I've renamed the flag so it clearer now (it would be possible to have kafka running in a different k8s namespace than the kubeless controller).