### PR TITLE
keep controller running all the time

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -232,7 +232,6 @@ func (c *Controller) monitor(httpClient *http.Client, watchVersion string) <-cha
 		for {
 			resp, err := utils.WatchResources(httpClient, watchVersion)
 			if err != nil {
-				resp.Body.Close()
 				c.logger.Errorf("Fail to watch resources: %v. Try again", err)
 				// go to the next round
 				continue
@@ -263,7 +262,6 @@ func (c *Controller) monitor(httpClient *http.Client, watchVersion string) <-cha
 				}
 
 				if st != nil {
-					resp.Body.Close()
 					if st.Code == http.StatusGone { // event history is outdated
 						err = errVersionOutdated // go to recovery path
 						// keep polling next event


### PR DESCRIPTION
The root problem of #117 is kubeless controller makes return for whatever unexpected errors the monitor function might have. It leads to the stop watching of the controller immediately.

This PR aims to keep the controller keep running all the time.