### PR TITLE
A container to sync k8s events and examples

### DIFF
--- a/docker/events/kubernetes/Dockerfile
+++ b/docker/events/kubernetes/Dockerfile
@@ -1,0 +1,16 @@
+FROM bitnami/minideb:jessie
+
+RUN install_packages python3 curl ca-certificates git
+RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+RUN python3 ./get-pip.py
+RUN pip3 install --upgrade kubernetes
+RUN pip3 install --upgrade requests
+
+RUN git clone https://github.com/dpkp/kafka-python
+WORKDIR kafka-python
+RUN python3 ./setup.py install
+
+WORKDIR /
+ADD events.py .
+
+CMD ["python3", "/events.py"]

--- a/docker/events/kubernetes/README.md
+++ b/docker/events/kubernetes/README.md
@@ -1,0 +1,21 @@
+# Container to feed k8s events to kafka
+
+`local-events.py` is a Python 3.6 script, that uses `asyncio` and the Kubernetes python client to watch for events in several k8s resources.
+
+`events.py` is a Python 3.4 script, that uses `asyncio` and the Kubernetes python client plus a Kafka client to watch for k8s events and send those events onto the kubeless Kafka _k8s_ topic.
+
+The Dockerfile just builds an image to start this as a deployment in a k8s cluster running kubeless.
+
+## Usage
+
+Create the `k8s` topic in kubeless:
+
+```
+kubeless topic create k8s
+```
+
+Then launch the event sync
+
+```
+kubectl run event --image=skippbox/k8s-events:0.10.12
+```

--- a/docker/events/kubernetes/events.py
+++ b/docker/events/kubernetes/events.py
@@ -1,0 +1,95 @@
+import asyncio
+import logging
+import json
+
+from kubernetes import client, config, watch
+
+from kafka import KafkaProducer
+from kafka.errors import KafkaError
+
+logger = logging.getLogger('k8s_events')
+logger.setLevel(logging.DEBUG)
+
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+#config.load_kube_config()
+config.load_incluster_config()
+
+v1 = client.CoreV1Api()
+v1ext = client.ExtensionsV1beta1Api()
+
+producer=KafkaProducer(bootstrap_servers='kafka.kubeless:9092',value_serializer=lambda v: json.dumps(v).encode('utf-8'))
+
+@asyncio.coroutine
+def pods():
+    w = watch.Watch()
+    for event in w.stream(v1.list_pod_for_all_namespaces):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        msg = {'type':event['type'],'object':event['raw_object']}
+        producer.send('k8s', msg)
+        producer.flush()
+        yield from asyncio.sleep(0.1) 
+
+@asyncio.coroutine
+def namespaces():
+    w = watch.Watch()
+    for event in w.stream(v1.list_namespace):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        msg = {'type':event['type'],'object':event['raw_object']}
+        producer.send('k8s', msg)
+        producer.flush()
+        yield from asyncio.sleep(0.1)
+        
+@asyncio.coroutine
+def services():
+    w = watch.Watch()
+    for event in w.stream(v1.list_service_for_all_namespaces):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        producer=KafkaProducer(bootstrap_servers='kafka.kubeless:9092',value_serializer=lambda v: json.dumps(v).encode('utf-8'))
+        msg = {'type':event['type'],'object':event['raw_object']}
+        producer.send('k8s', msg)
+        producer.flush()
+        yield from asyncio.sleep(0.1)
+
+@asyncio.coroutine        
+def deployments():
+    w = watch.Watch()
+    for event in w.stream(v1ext.list_deployment_for_all_namespaces):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        msg = {'type':event['type'],'object':event['raw_object']}
+        producer.send('k8s', msg)
+        producer.flush()
+        yield from asyncio.sleep(0.1)
+
+@asyncio.coroutine    
+def replicasets():
+    w = watch.Watch()
+    for event in w.stream(v1ext.list_replica_set_for_all_namespaces):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        msg = {'type':event['type'],'object':event['raw_object']}
+        producer.send('k8s', msg)
+        producer.flush()
+        yield from asyncio.sleep(0.1)
+
+ioloop = asyncio.get_event_loop()
+
+ioloop.create_task(pods())
+ioloop.create_task(namespaces())
+ioloop.create_task(services())
+ioloop.create_task(deployments())
+ioloop.create_task(replicasets())
+
+try:
+    # Blocking call interrupted by loop.stop()
+    print('step: loop.run_forever()')
+    ioloop.run_forever()
+except KeyboardInterrupt:
+    pass
+finally:
+    print('step: loop.close()')
+    ioloop.close()

--- a/docker/events/kubernetes/local-events.py
+++ b/docker/events/kubernetes/local-events.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+import json
+
+from kubernetes import client, config, watch
+
+logger = logging.getLogger('k8s_events')
+logger.setLevel(logging.DEBUG)
+
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+config.load_kube_config()
+#config.load_incluster_config()
+
+v1 = client.CoreV1Api()
+v1ext = client.ExtensionsV1beta1Api()
+
+async def pods():
+    w = watch.Watch()
+    for event in w.stream(v1.list_pod_for_all_namespaces):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        await asyncio.sleep(0) 
+
+async def namespaces():
+    w = watch.Watch()
+    for event in w.stream(v1.list_namespace):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        await asyncio.sleep(0)
+        
+async def services():
+    w = watch.Watch()
+    for event in w.stream(v1.list_service_for_all_namespaces):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        await asyncio.sleep(0)
+        
+async def deployments():
+    w = watch.Watch()
+    for event in w.stream(v1ext.list_deployment_for_all_namespaces):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        await asyncio.sleep(0)
+    
+async def replicasets():
+    w = watch.Watch()
+    for event in w.stream(v1ext.list_replica_set_for_all_namespaces):
+        logger.info("Event: %s %s %s" % (event['type'], event['object'].kind, event['object'].metadata.name))
+        await asyncio.sleep(0)
+
+ioloop = asyncio.get_event_loop()
+
+ioloop.create_task(pods())
+ioloop.create_task(namespaces())
+ioloop.create_task(services())
+ioloop.create_task(deployments())
+ioloop.create_task(replicasets())
+
+try:
+    # Blocking call interrupted by loop.stop()
+    print('step: loop.run_forever()')
+    ioloop.run_forever()
+except KeyboardInterrupt:
+    pass
+finally:
+    print('step: loop.close()')
+    ioloop.close()

--- a/examples/minio/slack/Makefile
+++ b/examples/minio/slack/Makefile
@@ -1,0 +1,2 @@
+slack:
+	kubeless function deploy slack --trigger-topic s3 --from-file bot.py --handler bot.handler --runtime python2.7 --dependencies requirements.txt

--- a/examples/slack/Makefile
+++ b/examples/slack/Makefile
@@ -1,3 +1,5 @@
 slack:
 	kubeless function deploy slack --trigger-http --runtime python27 --handler bot.handler --from-file bot.py --dependencies requirements.txt
 	echo "curl localhost:8080/api/v1/proxy/namespaces/default/services/slack/"
+events:
+        kubeless function deploy k8s-events --trigger-topic k8s --from-file botevents.py --handler botevents.handler --runtime python2.7 --dependencies requirements.txt

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -28,5 +28,17 @@ With a local proxy running:
 curl --data '{"msg":"This is a message to SLACK"}' localhost:8080/api/v1/proxy/namespaces/default/services/slack/ --header "Content-Type:application/json"
 ```
 
+## Listen to Kubernetes events in SLACK
 
+Launch the Kafka event sync:
 
+```
+kubeless topic create k8s
+kubectl run events --image=skippbox/k8s-events:0.10.12
+```
+
+Deploy the function to get triggered on k8s events and send message to SLACK
+
+```
+make slack
+```

--- a/examples/slack/botevents.py
+++ b/examples/slack/botevents.py
@@ -1,0 +1,31 @@
+import json
+import base64
+import tempfile
+
+#pip install slackclient
+from slackclient import SlackClient
+
+#pip install kubernetes
+from kubernetes import client, config
+
+config.load_incluster_config()
+
+v1=client.CoreV1Api()
+
+#Get minio and slack secrets
+for secrets in v1.list_secret_for_all_namespaces().items:
+    if secrets.metadata.name == 'slack':
+        token = base64.b64decode(secrets.data['token'])
+
+sc = SlackClient(token)
+
+def handler(context):
+    msg = "k8s event: %s" % context
+
+    sc.api_call(
+                "chat.postMessage",
+                channel="#bot",
+                text=msg
+               )
+
+    return "Notification sent to SLACK"


### PR DESCRIPTION
This is an example of writing a kubernetes events "bridge" to the kubeless kafka.

The container `skippbox/k8s-events:0.10.12` will listen to events using the python client and produce messages onto a `k8s` kafka topic.

Then there is a SLACK function example, which gets triggered on the `k8s` topic and published the events to SLACK.