### PR TITLE
Report error for calling unknown function name.

### DIFF
--- a/cmd/kubeless/call.go
+++ b/cmd/kubeless/call.go
@@ -103,6 +103,9 @@ var callCmd = &cobra.Command{
 		//FIXME: we should only use restClient from client-go but now still have to use the old client for pf call
 		k8sClientSet := utils.GetClientOutOfCluster()
 		podName, err := utils.GetPodName(k8sClientSet, ns, funcName)
+		if err != nil {
+			logrus.Fatalf("Couldn't get the pod name: %v", err)
+		}
 		port, err := getLocalPort()
 		if err != nil {
 			logrus.Fatalf("Connection failed: %v", err)


### PR DESCRIPTION
For:
```
kubeless function call unknownfunc
```

There is a panic.