### PR TITLE
Rewrite python2.7 runtime to use bottle/uwsgi

### DIFF
--- a/docker/runtime/python-2.7/Dockerfile
+++ b/docker/runtime/python-2.7/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:2.7.11-alpine
 
-RUN apk add --no-cache python py-pip git
-RUN pip install --upgrade pip
-RUN pip install bottle
+RUN apk add --no-cache python py-pip
+RUN pip install -U pip==9.0.1
+RUN pip install bottle==0.12.13 cherrypy==8.9.1 wsgi-request-logger
 
 ADD kubeless.py /
 
 CMD ["python", "/kubeless.py"]
+EXPOSE 8080


### PR DESCRIPTION
Are you sitting down?  This change allows the python runtime to
handle *more than one request at a time* - I love living in the
future!

In particular: this allows the python runtime to continue responding
to livenessProbes even when the function is doing something time
consuming (like making a request to another remote service).

This change rewrites the python runtime to use a multithreaded
server (uwsgi), while keeping the same bottle-based python API.
Parallelism can be tweaked by using the UWSGI_PROCESSES/UWSGI_THREADS
container environment variables (default is a fairly modest 4/2).

Fixes #142