### PR TITLE
Add prometheus /metrics endpoint to python runtime

### DIFF
--- a/docker/events/event-consumer/Dockerfile
+++ b/docker/events/event-consumer/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:2.7.11-alpine
 
-RUN apk add --no-cache python py-pip git
+RUN apk add --no-cache python py-pip
 RUN pip install --upgrade pip
-RUN pip install kafka-python
+RUN pip install kafka-python prometheus_client
 
 ADD kubeless.py .
 
-CMD ["python", "-u", "/kubeless.py"]
+CMD ["python", "/kubeless.py"]
+EXPOSE 8080

--- a/docker/events/event-consumer/kubeless.py
+++ b/docker/events/event-consumer/kubeless.py
@@ -1,34 +1,60 @@
 #!/usr/bin/env python
 
 import sys
+import traceback
 import os
 import imp
 import json
 
 from kafka import KafkaConsumer
+import prometheus_client as prom
 
 mod_name = os.getenv('MOD_NAME')
 func_handler = os.getenv('FUNC_HANDLER')
 topic_name = os.getenv('TOPIC_NAME')
 
-mod_path = '/kubeless/' + mod_name + '.py'
 group = mod_name + func_handler
 
-try:
-    mod = imp.load_source('function', mod_path)
-except ImportError:
-    print("No valid module found for the name: function, Failed to import module")
+mod = imp.load_source('function', '/kubeless/%s.py' % mod_name)
+func = getattr(mod, func_handler)
+
+func_hist = prom.Histogram('function_duration_seconds',
+                           'Duration of user function in seconds',
+                           ['topic'])
+func_calls = prom.Counter('function_calls_total',
+                           'Number of calls to user function',
+                          ['topic'])
+func_errors = prom.Counter('function_failures_total',
+                           'Number of exceptions in user function',
+                           ['topic'])
 
 def json_safe_loads(msg):
     try:
         data = json.loads(msg)
-        return {'type':'json','payload':data}
+        return {'type': 'json', 'payload': data}
     except:
-        return {'type':'text','payload':msg}
+        return {'type': 'text', 'payload': msg}
 
-consumer=KafkaConsumer(bootstrap_servers='kafka.kubeless:9092', group_id=group, value_deserializer=json_safe_loads)
+consumer = KafkaConsumer(
+    bootstrap_servers='kafka.kubeless:9092',
+    group_id=group, value_deserializer=json_safe_loads)
 consumer.subscribe([topic_name])
-while True:
-    for msg in consumer:
-        res = getattr(mod, func_handler)(msg.value['payload'])
-        print res
+
+def handle(msg):
+    func_calls.labels(topic_name).inc()
+    with func_errors.labels(topic_name).count_exceptions():
+        with func_hist.labels(topic_name).time():
+            return func(msg.value['payload'])
+
+if __name__ == '__main__':
+    prom.start_http_server(8080)
+
+    while True:
+        for msg in consumer:
+            try:
+                res = handle(msg)
+                sys.stdout.write(str(res) + '\n')
+                sys.stdout.flush()
+
+            except Exception:
+                traceback.print_exc()

--- a/docker/runtime/python-2.7/Dockerfile
+++ b/docker/runtime/python-2.7/Dockerfile
@@ -2,7 +2,7 @@ FROM python:2.7.11-alpine
 
 RUN apk add --no-cache python py-pip
 RUN pip install -U pip==9.0.1
-RUN pip install bottle==0.12.13 cherrypy==8.9.1 wsgi-request-logger
+RUN pip install bottle==0.12.13 cherrypy==8.9.1 wsgi-request-logger prometheus_client
 
 ADD kubeless.py /
 

--- a/docker/runtime/python-2.7/kubeless.py
+++ b/docker/runtime/python-2.7/kubeless.py
@@ -4,6 +4,7 @@ import os
 import imp
 
 import bottle
+import prometheus_client as prom
 
 mod = imp.load_source('function',
                       '/kubeless/%s.py' % os.getenv('MOD_NAME'))
@@ -11,17 +12,36 @@ func = getattr(mod, os.getenv('FUNC_HANDLER'))
 
 app = application = bottle.app()
 
-@app.get('/')
-def handler():
-    return func()
+func_hist = prom.Histogram('function_duration_seconds',
+                           'Duration of user function in seconds',
+                           ['method'])
+func_calls = prom.Counter('function_calls_total',
+                           'Number of calls to user function',
+                          ['method'])
+func_errors = prom.Counter('function_failures_total',
+                           'Number of exceptions in user function',
+                           ['method'])
 
-@app.post('/')
-def post_handler():
-    return func(bottle.request)
+@app.route('/', method=['GET', 'POST'])
+def handler():
+    req = bottle.request
+    method = req.method
+    func_calls.labels(method).inc()
+    with func_errors.labels(method).count_exceptions():
+        with func_hist.labels(method).time():
+            if method == 'GET':
+                return func()
+            else:
+                return func(bottle.request)
 
 @app.get('/healthz')
 def healthz():
     return 'OK'
+
+@app.get('/metrics')
+def metrics():
+    bottle.response.content_type = prom.CONTENT_TYPE_LATEST
+    return prom.generate_latest(prom.REGISTRY)
 
 if __name__ == '__main__':
     import logging

--- a/examples/python/function1.yaml
+++ b/examples/python/function1.yaml
@@ -6,12 +6,17 @@ metadata:
 spec:
   handler: hello.foobar
   runtime: python2.7
+  deps: |
+    cowpy
   function: |
       import time
       import random
+      from cowpy import cow
       def foobar():
         # NB: delay will be negative and sleep will raise an error
         # occasionally.  This is a feature for demoing errors.
         delay = random.normalvariate(0.3, 0.2)
         time.sleep(delay)
-        return "hello world - with a %0.2fs artificial delay" % delay
+        msg = "hello world - with a %0.2fs artificial delay" % delay
+        c = cow.get_cow()
+        return c().milk(msg)

--- a/examples/python/function1.yaml
+++ b/examples/python/function1.yaml
@@ -7,6 +7,11 @@ spec:
   handler: hello.foobar
   runtime: python2.7
   function: |
-      import json
+      import time
+      import random
       def foobar():
-              return "hello world"
+        # NB: delay will be negative and sleep will raise an error
+        # occasionally.  This is a feature for demoing errors.
+        delay = random.normalvariate(0.3, 0.2)
+        time.sleep(delay)
+        return "hello world - with a %0.2fs artificial delay" % delay

--- a/manifests/monitoring/prometheus.yaml
+++ b/manifests/monitoring/prometheus.yaml
@@ -16,6 +16,9 @@ data:
     scrape_configs:
     - job_name: 'kubernetes-cluster'
       scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - api_servers:
         - 'https://kubernetes.default.svc'
@@ -23,6 +26,9 @@ data:
         role: apiserver
     - job_name: 'kubernetes-nodes'
       scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
       kubernetes_sd_configs:
       - api_servers:
         - 'https://kubernetes.default.svc'
@@ -32,7 +38,7 @@ data:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
     - job_name: 'kubernetes-service-endpoints'
-      scheme: https
+      scheme: http
       kubernetes_sd_configs:
       - api_servers:
         - 'https://kubernetes.default.svc'
@@ -49,7 +55,7 @@ data:
         action: replace
         target_label: kubernetes_name
     - job_name: 'kubernetes-services'
-      scheme: https
+      scheme: http
       kubernetes_sd_configs:
       - api_servers:
         - 'https://kubernetes.default.svc'
@@ -64,7 +70,7 @@ data:
       - source_labels: [__meta_kubernetes_service_name]
         target_label: kubernetes_name
     - job_name: 'kubernetes-pods'
-      scheme: https
+      scheme: http
       kubernetes_sd_configs:
       - api_servers:
         - 'https://kubernetes.default.svc'
@@ -74,6 +80,17 @@ data:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: (.+):(?:\\d+);(\\d+)
+        replacement: ${1}:${2}
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_pod_namespace]
         action: replace
         target_label: kubernetes_namespace
@@ -83,16 +100,6 @@ data:
       - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
         target_label: kubernetes_pod_node_name
-    - job-name: 'kubeless functions'
-      kubernetes_sd_configs:
-      - api_servers:
-        - 'https://kubernetes.default.svc'
-        in_cluster: true
-        role: pod
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_label_app]
-        regex: kubeless
-        action: keep
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -210,6 +210,16 @@ func CreateK8sResources(ns, name string, spec *spec.FunctionSpec, client *kubern
 	labels := map[string]string{
 		"function": name,
 	}
+	podAnnotations := map[string]string{
+		// Attempt to attract the attention of prometheus.
+		// For runtimes that don't support /metrics,
+		// prometheus will get a 404 and mostly silently
+		// ignore the pod (still displayed in the list of
+		// "targets")
+		"prometheus.io/scrape": "true",
+		"prometheus.io/path":   "/metrics",
+		"prometheus.io/port":   "8080",
+	}
 	data := map[string]string{
 		"handler": spec.Handler,
 		fileName:  spec.Function,
@@ -273,7 +283,8 @@ func CreateK8sResources(ns, name string, spec *spec.FunctionSpec, client *kubern
 		Spec: v1beta1.DeploymentSpec{
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: podAnnotations,
 				},
 				Spec: v1.PodSpec{
 					InitContainers: initContainer,

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -54,8 +54,8 @@ import (
 const (
 	controllerImage = "bitnami/kubeless-controller"
 	kafkaImage      = "wurstmeister/kafka"
-	pythonRuntime   = "skippbox/kubeless-python:0.0.5"
-	pubsubRuntime   = "skippbox/kubeless-event-consumer:0.0.5"
+	pythonRuntime   = "bitnami/kubeless-python@sha256:2d0412e982a8e831dee056aee49089e1d5edd65470e479dcbc7d60bb56ea2b71"
+	pubsubRuntime   = "bitnami/kubeless-event-consumer@sha256:9c29b8ec6023040492226a55b19781bc3a8911d535327c773ee985895515e905"
 	nodejsRuntime   = "rosskukulinski/kubeless-nodejs:0.0.0"
 	rubyRuntime     = "jbianquettibitnami/kubeless-ruby:0.0.0"
 	pubsubFunc      = "PubSub"


### PR DESCRIPTION
Exports basic function_duration_seconds histogram, and
function_{calls,failures}_total counters, all labelled with HTTP
method.

Also adds prometheus annotations to function Deployment.